### PR TITLE
chore: add /usr/share/mime/packages/flatpost.xml

### DIFF
--- a/.github/workflows/build-flatpost-f41.yml
+++ b/.github/workflows/build-flatpost-f41.yml
@@ -29,7 +29,7 @@ jobs:
         run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
 
       - name: Install build dependencies
-        run: dnf install -y git rpm-build make python3-devel python3-build
+        run: dnf install -y git rpm-build make python3-devel python3-build desktop-file-utils
 
       - name: Extract Version and SHA
         run: |

--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,7 @@ PYTHON_SITE_PACKAGES := $(shell python3 -c "import site; print(site.getsitepacka
 TARGET_DIR := $(DESTDIR)$(PYTHON_SITE_PACKAGES)/flatpost
 BIN_DIR := $(DESTDIR)/usr/bin
 DESKTOP_DIR := $(DESTDIR)/usr/share/applications
+MIME_DIR := $(DESTDIR)/usr/share/mime/packages
 DATA_DIR := $(DESTDIR)/usr/share/flatpost
 ICON_DIR := $(DESTDIR)/usr/share/icons/hicolor
 LICENSE_DIR := $(DESTDIR)/usr/share/licenses/flatpost
@@ -25,6 +26,10 @@ install:
 	@echo "Installing desktop file to $(DESKTOP_DIR)"
 	mkdir -p $(DESKTOP_DIR)
 	install -m 644 data/usr/share/applications/com.flatpost.flatpostapp.desktop $(DESKTOP_DIR)/com.flatpost.flatpostapp.desktop
+
+	@echo "Installing MIME file to $(MIME_DIR)"
+	mkdir -p $(MIME_DIR)
+	install -m 644 data/usr/share/mime/packages/flatpost.xml $(MIME_DIR)/flatpost.xml
 
 	@echo "Installing data files to $(DATA_DIR)"
 	mkdir -p $(DATA_DIR)

--- a/data/usr/share/mime/packages/flatpost.xml
+++ b/data/usr/share/mime/packages/flatpost.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<mime-info xmlns="http://www.freedesktop.org/standards/shared-mime-info">
+  <mime-type type="application/vnd.flatpak.ref">
+    <glob pattern="*.flatpakref"/>
+    <comment>Flatpak Reference File</comment>
+  </mime-type>
+  <mime-type type="application/vnd.flatpak.repo">
+    <glob pattern="*.flatpakrepo"/>
+    <comment>Flatpak Repository File</comment>
+  </mime-type>
+</mime-info>

--- a/packaging/rpm/flatpost.spec
+++ b/packaging/rpm/flatpost.spec
@@ -56,7 +56,6 @@ installation, removal, updating, and permission management of flatpak packages a
 
 %build
 make all DESTDIR=%{buildroot}
-install -D -m644  %{buildroot}/usr/share/mime/packages/flatpost.xml
 
 %check
 desktop-file-validate %{buildroot}%{_datadir}/applications/com.flatpost.flatpostapp.desktop

--- a/packaging/rpm/flatpost.spec
+++ b/packaging/rpm/flatpost.spec
@@ -21,6 +21,7 @@ Source0:        %{url}/archive/refs/tags/%{tag}.tar.gz#/%{name}-%{tag}.tar.gz
 BuildArch:      noarch
 BuildRequires:  python3-devel
 BuildRequires:  make
+BuildRequires:  desktop-file-utils
 
 Provides:	nobara-updater
 
@@ -40,6 +41,10 @@ Requires: gtk3
 Requires: gtk4
 Requires: xdg-utils
 
+Requires(post):      shared-mime-info
+Requires(postun):    shared-mime-info
+Requires(posttrans): shared-mime-info
+
 Provides: flatpost
 
 %description
@@ -51,20 +56,25 @@ installation, removal, updating, and permission management of flatpak packages a
 
 %build
 make all DESTDIR=%{buildroot}
+install -D -m644  %{buildroot}/usr/share/mime/packages/flatpost.xml
+
+%check
+desktop-file-validate %{buildroot}%{_datadir}/applications/com.flatpost.flatpostapp.desktop
 
 %post
-#!/bin/bash
+xdg-icon-resource forceupdate --theme hicolor &>/dev/null
+update-mime-database usr/share/mime &>/dev/null
+update-desktop-database -q
 
-# Check if we already have the association
-if [ ! -f /usr/bin/xdg-mime ]; then
-    # If xdg-mime is not available, skip this step
-    exit 0
-fi
+%postun
+xdg-icon-resource forceupdate --theme hicolor &>/dev/null
+update-mime-database usr/share/mime &>/dev/null
+update-desktop-database -q
 
-# Set the default application for .rpm files
-xdg-mime default /usr/share/applications/com.flatpost.flatpostapp.desktop application/vnd.flatpak.ref
-xdg-mime default /usr/share/applications/com.flatpost.flatpostapp.desktop application/vnd.flatpak.repo
-update-mime-database /usr/share/mime
+%posttrans
+xdg-icon-resource forceupdate --theme hicolor &>/dev/null
+update-mime-database usr/share/mime &>/dev/null
+update-desktop-database -q
 
 %files
 %{python3_sitelib}/flatpost/
@@ -73,6 +83,7 @@ update-mime-database /usr/share/mime
 %{_datadir}/flatpost/collections_data.json
 %{_datadir}/icons/hicolor/1024x1024/apps/com.flatpost.flatpostapp.png
 %{_datadir}/icons/hicolor/64x64/apps/com.flatpost.flatpostapp.png
+%{_datadir}/mime/packages/flatpost.xml
 %license %{_datadir}/licenses/flatpost/LICENSE
 
 %clean


### PR DESCRIPTION
This PR replaces the calls in the spec file to `xdg-mime` with a drop in file for MIME types at `/usr/share/mime/packages/flatpost.xml`.

These changes already exist in the Terra package https://github.com/terrapkg/packages/tree/frawhide/anda/apps/flatpost and I'm just upstreaming them here.